### PR TITLE
Making delete feature less picky, and adding documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,73 @@ Specify your local folder of source code with the --sync-dir command line option
 
 If the --delete option is specified, files on your MicroPython board that aren't in your source folder will be automatically deleted from the device.
 
+## Dependencies
+
+* (https://pypi.org/project/pyserial/)[pyserial]
+
+## Example
+
+# Set up virtualenv (optional)
+```shell
+$ virtualenv venv
+New python executable in venv/bin/python
+Installing setuptools, pip, wheel...done.
+$ source venv/bin/activate
+(venv) $
+```
+
+#### Install dependencies
+```shell
+(venv) $ pip install -r requirements.txt
+Collecting pyserial (from -r requirements.txt (line 1))
+  Using cached https://files.pythonhosted.org/packages/0d/e4/2a744dd9e3be04a0c0907414e2a01a7c88bb3915cbe3c8cc06e209f59c30/pyserial-3.4-py2.py3-none-any.whl
+  Installing collected packages: pyserial
+  Successfully installed pyserial-3.4
+```
+
+
+#### Set up a new hello world program
+```shell
+$ mkdir src
+$ touch src/boot.py
+$ echo 'print("Hello world!")' > src/main.py
+$
+
+#### Run mpy-miniterm with syncing, and deleting of files that are only on the MicroPython side.
+```shell
+(venv) $ python mpy-miniterm.py /dev/tty.SLAB_USBtoUART --sync-dir src/ --delete
+--- Miniterm on /dev/tty.SLAB_USBtoUART  115200,8,N,1 ---
+--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---
+
+>>>
+>>>
+
+<press ctrl-T, then ctrl-G to trigger syncing>
+
+--- Synchronising MicroPython code ---
+copying   'src/boot.py' => 'boot.py'
+copying   'src/main.py' => 'main.py'
+
+MicroPython v1.9.4-8-ga9a3caad0 on 2018-05-11; ESP module with ESP8266
+Type "help()" for more information.
+>>>
+
+<press ctrl-D to restart MicroPython>
+
+PYB: soft reboot
+#7 ets_task(40100130, 3, 3fff83ec, 4)
+Hello world!
+MicroPython v1.9.4-8-ga9a3caad0 on 2018-05-11; ESP module with ESP8266
+Type "help()" for more information.
+>>>
+```
+
+#### Exiting mpy-miniterm
+```shell
+>>>
+
+<press ctrl-]>
+
+--- exit ---
+(venv) $
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If the --delete option is specified, files on your MicroPython board that aren't
 
 ## Dependencies
 
-* (https://pypi.org/project/pyserial/)[pyserial]
+* [https://pypi.org/project/pyserial/](pyserial)
 
 ## Example
 
@@ -44,6 +44,7 @@ $ mkdir src
 $ touch src/boot.py
 $ echo 'print("Hello world!")' > src/main.py
 $
+```
 
 #### Run mpy-miniterm with syncing, and deleting of files that are only on the MicroPython side.
 ```shell

--- a/mpy-miniterm.py
+++ b/mpy-miniterm.py
@@ -1010,6 +1010,12 @@ def main(default_port=None, default_baudrate=115200, default_rts=None, default_d
 
     syncdir = args.sync_dir
 
+    # syncdir should always have a trailing slash to make sure path comparison
+    # in mpy_delete_strays() matches. Otherwise, it's possible to sync some
+    # changes and then immediately delete those files, which is useless.
+    if not syncdir.endswith("/"):
+        syncdir += "/"
+
     if args.menu_char == args.exit_char:
         parser.error('--exit-char can not be the same as --menu-char')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyserial


### PR DESCRIPTION
This PR makes the delete feature less picky by quietly adding a trailing slash to the path the user specifies, which means we avoid this silly situation:

```shell
(venv) $ python mpy-miniterm.py /dev/tty.SLAB_USBtoUART --sync-dir src --delete
--- Miniterm on /dev/tty.SLAB_USBtoUART  115200,8,N,1 ---
--- Quit: Ctrl+] | Menu: Ctrl+T | Help: Ctrl+T followed by Ctrl+H ---

--- Synchronising MicroPython code ---
copying   'src/boot.py' => 'src/boot.py'
copying   'src/main.py' => 'src/main.py'
Deleting file /src/boot.py
Deleting file /src/main.py
Removing directory /src
```

That just synced my changes, then incorrectly didn't get a match for the paths, and deleted everything. Changing ```--sync-dir``` from ```src``` to ```src/``` is a workaround but shouldn't be necessary.

This PR also adds some documentation to the README, and adds a ```requirements.txt ```specifying the dependencies. (which just seems to be pyserial)