### PR TITLE
Use the raw paste REPl interface for helpers.

### DIFF
--- a/helper_fns.py
+++ b/helper_fns.py
@@ -1,0 +1,16 @@
+import os
+import uhashlib as hashlib
+import ubinascii as binascii
+
+def sha256(fn):
+    hash_sha256 = hashlib.sha256()
+    try:
+        f = open(fn, 'rb')
+        while True:
+            c = f.read(1024)
+            if not c:
+                break
+            hash_sha256.update(c)
+        return binascii.hexlify(hash_sha256.digest())
+    except OSError:
+        return None


### PR DESCRIPTION
This fixes an issue where mpy-miniterm can hang when writing the helper functions. Probably some buffer is too small on the LILYGO T-Deck? This PR instead uses the raw paste REPL mode to copy in code from a given file.

Flow control code modified from https://github.com/micropython/micropython/blob/bd21820b4cc7d3c6c293b2fd104cb8214df686cd/tools/pyboard.py#L404.

Note that the documentation alludes to the possibility that not all devices will support the raw paste REPL mode, and I haven't added any code to handle that scenario. It is supported on all the devices I had to hand...

Bonus: a fix for sometimes hanging while waiting for the REPL, by retrying once a second until we see the correct response.

fileExists function removed because it doesn't seem to be in use.